### PR TITLE
Fix: Correct SyntaxError in NRS/nodes_NRS.py

### DIFF
--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -15,7 +15,7 @@ class NRS:
                               # Adjusts the target length for Squashing, as a factor of original cond_len.
                               "squash_target_length_factor": ("FLOAT", {"default": 1.0, "min": 0.5, "max": 2.0, "step": 0.01}),
                               # Blends the final NRS effect with the original (rescaled) conditioned tensor. 1.0 is full NRS.
-                              "nrs_effect_blend": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                              "nrs_effect_blend": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01})
                               }}
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"


### PR DESCRIPTION
I've removed an extraneous trailing comma within the INPUT_TYPES definition for the NRS node. This comma caused a SyntaxError: '{' was never closed when ComfyUI attempted to load the custom node.

The specific change is removing the comma from the "nrs_effect_blend" entry, ensuring the dictionary is correctly formatted.