### PR TITLE
Fix(NRS): Correct denoising process for NRSEpsilon node

### DIFF
--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -203,8 +203,8 @@ class NRSEpsilon:
 
             #rescale cfg has to be done on v-pred model output
             x = x_orig # Changed for EpsilonPred
-            cond = ((x - (x_orig - cond)) * (sigma ** 2 + 1.0) ** 0.5) / (sigma)
-            uncond = ((x - (x_orig - uncond)) * (sigma ** 2 + 1.0) ** 0.5) / (sigma)
+            cond = args["cond"]
+            uncond = args["uncond"]
             logging.debug(f"NRS.nrs: generated cond and uncond")
 
             x_final = None


### PR DESCRIPTION
The NRSEpsilon node was previously applying a V-prediction-specific scaling to its input `cond` and `uncond` tensors. This is incorrect for epsilon-prediction models, where these tensors are direct noise estimates.

This commit modifies the `NRSEpsilon` node's `patch` method to use the `cond` and `uncond` arguments directly from the model's output (i.e., `args["cond"]` and `args["uncond"]`). The `x = x_orig` and `return x_final` statements remain, as they are appropriate for epsilon-prediction models where `x_final` represents the modified epsilon.

This change ensures that the core NRS vector mathematics (skew, stretch, squash) operates on the correct domain (epsilon/noise space) when using the NRSEpsilon node, aligning its behavior more closely with the intended denoising process.