### PR TITLE
Fix and complete adaptive normalization feature for NRSEpsilon

### DIFF
--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -181,179 +181,81 @@ class NRS:
 class NRSEpsilon:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": { "model": ("MODEL",),
-                              "skew": ("FLOAT", {"default": 4.0, "min": -30.0, "max": 30.0, "step": 0.01}),
-                              "stretch": ("FLOAT", {"default": 2.0, "min": -30.0, "max": 30.0, "step": 0.01}),
-                              "squash": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
-                              }}
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "skew": ("FLOAT", {"default": 4.0, "min": -30.0, "max": 30.0, "step": 0.01}),
+                "stretch": ("FLOAT", {"default": 2.0, "min": -30.0, "max": 30.0, "step": 0.01}),
+                "squash": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "normalize_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+            }
+        }
+
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
-
     CATEGORY = "advanced/model"
 
-    def patch(self, model, skew, stretch, squash):
+    def patch(self, model, skew, stretch, squash, normalize_strength):
+        # It's important to import torch and logging if they are not already top-level in the file.
+        # Assuming 'torch' and 'logging' are available in the scope from file-level imports.
+
         def nrs(args):
             cond = args["cond"]
             uncond = args["uncond"]
-            sigma = args["sigma"]
-            sigma = sigma.view(sigma.shape[:1] + (1,) * (cond.ndim - 1))
-            x_orig = args["input"]
+            # sigma = args["sigma"] # Not used here
+            # x_orig = args["input"] # Not used here
 
-            logging.debug(f"NRS.nrs: Skew: {skew}, Stretch: {stretch}, Squash: {squash}")
-
-            #rescale cfg has to be done on v-pred model output
-            x = x_orig # Changed for EpsilonPred
-            cond = args["cond"]
-            uncond = args["uncond"]
-            logging.debug(f"NRS.nrs: generated cond and uncond")
+            # Use logging if available, otherwise this line would need to be conditional or removed.
+            # logging.debug(f"NRSEpsilon.nrs: Skew: {skew}, Stretch: {stretch}, Squash: {squash}, Normalize: {normalize_strength}")
 
             x_final = None
-            match "v0.4.5":
-                case "v1":
-                    # displace cond by rejection of uncond on cond
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c = (u_dot_c / c_dot_c) * cond
-                    u_rej_c = uncond - u_on_c
-                    displaced = (cond - skew * u_rej_c)
-                    logging.debug(f"NRS.nrs: displaced")
 
-                    # squash displaced vector towards len(cond) based on squash scale
-                    d_len_sq = torch.sum(displaced * displaced, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * ((c_dot_c/d_len_sq) ** 0.5)
-                    squashed = displaced * squash_scale
-                    logging.debug(f"NRS.nrs: squashed")
+            # v0.4.5 steering logic (embedded directly)
+            u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+            c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
 
-                    # stretch turned vector towards cond based on stretch scale
-                    sq_dot_c = torch.sum(squashed * cond, dim=-1, keepdim=True)
-                    sq_on_c = (sq_dot_c / c_dot_c) * cond
-                    x_final = squashed + sq_on_c * stretch
-                    logging.debug(f"NRS.nrs: final")
-                case "v2":
-                    # displace cond by rejection of uncond on cond
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    displaced = cond + stretch * (cond - torch.clamp(u_dot_c / c_dot_c, min=0, max=1) * cond) - skew * u_rej_c
-                    logging.debug(f"NRS.nrs: displaced & stretched")
+            epsilon_steering = 1e-6
+            u_on_c_mag = (u_dot_c / (c_dot_c + epsilon_steering))
 
-                    # squash displaced vector towards len(cond) based on squash scale
-                    d_len_sq = torch.sum(displaced * displaced, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * ((c_dot_c/d_len_sq) ** 0.5)
-                    x_final = displaced * squash_scale
-                    logging.debug(f"NRS.nrs: final")
-                case "v3":
-                    # displace cond by rejection of uncond on cond
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    displaced = (cond - skew * u_rej_c)
-                    logging.debug(f"NRS.nrs: displaced")
+            u_on_c = u_on_c_mag * cond
+            u_rej_c = uncond - u_on_c
 
-                    # squash displaced vector towards len(cond) based on squash scale
-                    d_len_sq = torch.sum(displaced * displaced, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * ((c_dot_c/d_len_sq) ** 0.5)
+            cond_len_sq = c_dot_c
+            cond_len = torch.sqrt(cond_len_sq + epsilon_steering)
 
-                    # stretch vector towards 2*len(cond) - len(u_on_c)
-                    c_len = c_dot_c ** 0.5
-                    stretch_scale = (1 - stretch) + stretch * (2 * c_len - u_on_c_mag)/c_len
+            proj_diff = cond - u_on_c
 
-                    x_final = displaced * squash_scale * stretch_scale
-                    logging.debug(f"NRS.nrs: final")
-                case "v4":
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    rej_dor_rej = torch.sum(u_rej_c * u_rej_c, dim=-1, keepdim=True)
-                    x_final = (cond - squash * u_rej_c + stretch * cond * ((rej_dor_rej/c_dot_c) ** 0.5))
-                    logging.debug(f"NRS.nrs: displaced")
-                case "v0.4.1":
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    rej_dor_rej = torch.sum(u_rej_c * u_rej_c, dim=-1, keepdim=True)
-                    stretched = cond + stretch * cond * ((rej_dor_rej/c_dot_c) ** 0.5)
-                    skewed = stretched - skew * u_rej_c
-                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * ((c_dot_c/sk_dot_sk) ** 0.5)
-                    x_final = skewed * squash_scale
-                    logging.debug(f"NRS.nrs: displaced")
-                case "v0.4.2":
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    proj_len = torch.sum(u_on_c * u_on_c, dim=-1, keepdim=True) ** 0.5
-                    cond_len = c_dot_c ** 0.5
-                    stretched = cond * (1 + stretch * torch.abs(cond_len - proj_len) / cond_len)
-                    skewed = stretched - skew * u_rej_c
-                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
-                    x_final = skewed * squash_scale
-                    logging.debug(f"NRS.nrs: displaced")
-                case "v0.4.3":
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    proj_len = torch.sum(u_on_c * u_on_c, dim=-1, keepdim=True) ** 0.5
-                    cond_len = c_dot_c ** 0.5
-                    stretched = cond * (1 + stretch * (cond_len - proj_len) / cond_len)
-                    skewed = stretched - skew * u_rej_c
-                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
-                    x_final = skewed * squash_scale
-                    logging.debug(f"NRS.nrs: displaced")
-                case "v0.4.4":
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    cond_len = c_dot_c ** 0.5
-                    proj_diff = cond - u_on_c
-                    proj_diff_len = torch.sum(proj_diff * proj_diff, dim=-1, keepdim=True) ** 0.5
-                    stretched = cond * (1 + stretch * proj_diff_len / cond_len)
-                    skewed = stretched - skew * u_rej_c
-                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
-                    x_final = skewed * squash_scale
-                    logging.debug(f"NRS.nrs: displaced")
-                case "v0.4.5":
-                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                    u_on_c_mag = (u_dot_c / c_dot_c)
-                    u_on_c = u_on_c_mag * cond
-                    u_rej_c = uncond - u_on_c
-                    cond_len = c_dot_c ** 0.5
-                    proj_diff = cond - u_on_c
+            stretched = cond + (stretch * proj_diff)
+            skewed = stretched - skew * u_rej_c
 
-                    # Amplify Cond based on length compared to projection of uncond
-                    stretched = cond + (stretch * proj_diff)
+            sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
+            sk_dot_sk_sqrt = torch.sqrt(sk_dot_sk + epsilon_steering)
 
-                    # Skew/Steer Conf based on rejection of uncond on cond
-                    skewed = stretched - skew * u_rej_c
+            squash_scale = (1 - squash) + squash * (cond_len / (sk_dot_sk_sqrt + epsilon_steering))
+            x_final = skewed * squash_scale
 
-                    # Squash final length back down to original length of cond
-                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
-                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
-                    x_final = skewed * squash_scale
+            # Adaptive Normalization Logic
+            if normalize_strength > 0:
+                epsilon_norm = 1e-6
+                dims_to_reduce = tuple(range(2, cond.ndim))
 
-            return x_final # Changed for EpsilonPred
+                mean_cond = torch.mean(cond, dim=dims_to_reduce, keepdim=True)
+                var_cond = torch.var(cond, dim=dims_to_reduce, unbiased=False, keepdim=True)
+
+                mean_x_final_orig = torch.mean(x_final, dim=dims_to_reduce, keepdim=True)
+                var_x_final_orig = torch.var(x_final, dim=dims_to_reduce, unbiased=False, keepdim=True)
+
+                normalized_x_final_temp = (x_final - mean_x_final_orig) / (torch.sqrt(var_x_final_orig + epsilon_norm))
+                denormalized_x_final = normalized_x_final_temp * torch.sqrt(var_cond + epsilon_norm) + mean_cond
+
+                x_final = (1.0 - normalize_strength) * x_final + normalize_strength * denormalized_x_final
+
+            return x_final
 
         m = model.clone()
         m.set_model_sampler_cfg_function(nrs, True)
-        return (m, )
+        return (m,)
+
 
 NODE_CLASS_MAPPINGS = {
     "NRS": NRS,


### PR DESCRIPTION
This commit addresses issues from a previous attempt to add an adaptive normalization feature (controlled by `normalize_strength`) to the `NRSEpsilon` class in `NRS/nodes_NRS.py`.

Summary of actions:

1.  **Identified Incorrect Application:**
    *   The `normalize_strength` parameter and parts of its logic were mistakenly added to the `NRS` (v-prediction) class.
    *   The `NRSEpsilon` class was left in a broken state:
        *   `normalize_strength` was missing from `INPUT_TYPES`.
        *   `normalize_strength` was missing from the `patch` method signature.
        *   The normalization logic block itself was also missing.

2.  **Corrective Measures:**
    *   **`NRS` Class Restoration:** I removed all traces of `normalize_strength` from the `NRS` class, restoring it to its original intended state.
    *   **`NRSEpsilon` Class Correction (Full Replacement):**
        *   I reconstructed the entire `NRSEpsilon` class definition with the correct and complete code.
        *   This reconstructed block, including the `normalize_strength` parameter in `INPUT_TYPES` and the `patch` signature, the full v0.4.5 steering logic (with added epsilons for numerical stability), and the complete adaptive channel-wise normalization logic, successfully replaced the previous incorrect `NRSEpsilon` definition.

3.  **Verification:**
    *   I have reviewed the `NRS/nodes_NRS.py` file.
    *   I confirmed that the `NRS` class is correct.
    *   The `NRSEpsilon` class now correctly and fully implements the adaptive normalization feature as originally designed.

The `NRSEpsilon` node should now function correctly with the `normalize_strength` parameter, allowing you to mitigate color shifts by normalizing the steered noise against the original conditional noise prediction.