### PR TITLE
Refactor and refine adaptive normalization for NRS

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -71,6 +71,7 @@ The process involves:
 *   **Effect**:
     *   Applying adaptive normalization can help in producing images that have a more consistent statistical profile with what the model expects for conditioned outputs.
     *   It may lead to improved coherence, better preservation of certain details from the `cond` guidance, or a reduction in unexpected tonal shifts or artifacts that might arise from aggressive steering.
+    *   The process has been refined to be gentler: the adjustment to the signal's standard deviation is now clamped. This means it won't attempt to force the statistics to match if the difference is too large (e.g., the target standard deviation will not be more than a factor of K=10 times different from the original). This makes the normalization more robust against potential artifacts from drastic statistical shifts.
     *   The visual impact can vary depending on the model and other parameters, so experimentation is encouraged. For instance, if high Skew/Stretch values introduce undesirable color casts or intensity imbalances, `normalize_strength` might help to temper these effects by pulling the output's characteristics back towards the `cond` baseline.
 
 ## 4. `NRS` Node vs. `NRSEpsilon` Node


### PR DESCRIPTION
This commit addresses potential artifacts caused by the `normalize_strength` parameter in Negative Rejection Steering.

Key changes:
- I refactored the adaptive normalization logic into a shared helper function `_adaptive_normalize` used by both NRS and NRSEpsilon nodes.
- I modified the normalization to be gentler: the target standard deviation for denormalization is now clamped. It cannot be more than K_FACTOR (currently 10.0) times larger or smaller than the original standard deviation of the tensor being normalized. This prevents extreme statistical shifts that could lead to artifacts.
- I updated `DOCUMENTATION.md` to reflect this refinement.

The goal is to make the `normalize_strength` feature more robust and predictable, reducing the likelihood of it introducing undesirable visual effects while still allowing it to align statistical properties of the steered tensor with the conditioned tensor in a controlled manner.