### PR TITLE
Fix: Pass correct unconditional prediction to laplacian_guidance

### DIFF
--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -452,7 +452,7 @@ class NRS:
                     if sigma.item() > sample_sigmas[step_limits].item():
                         x_final = laplacian_guidance(
                             x_final,
-                            uncond,
+                            nrs_uncond,
                             guidance_scale,
                             parallel_weights
                         )


### PR DESCRIPTION
The `laplacian_guidance` function was being called with the original `uncond` tensor, which was not in the same prediction space as the NRS-modified `x_final` tensor. This mismatch caused the `fdg` feature to produce noise.

This change passes the correctly converted `nrs_uncond` tensor to the `laplacian_guidance` function, ensuring that both inputs are in the same prediction space.